### PR TITLE
centroidv2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: protViz
 Type: Package
 Title: Visualizing and Analyzing Mass Spectrometry Related Data in Proteomics
-Version: 0.6.6
+Version: 0.6.7
 Authors@R: c(person("Christian", "Panse", email = "cp@fgcz.ethz.ch", role = c("aut", "cre"), 
         comment = c(ORCID = "0000-0003-1975-3064")),
 	person("Jonas", "Grossmann", email = "jg@fgcz.ethz.ch", role = "aut",
@@ -12,7 +12,7 @@ Depends: R (>= 3.6),
 Imports: Rcpp (>= 1.0)
 LinkingTo: Rcpp (>= 1.0)
 RcppModules: FastaMod 
-Suggests:lattice,
+Suggests: lattice,
 	RUnit,
 	xtable
 Description: Helps with quality checks, visualizations 
@@ -26,6 +26,7 @@ URL: https://github.com/cpanse/protViz/
 BugReports: https://github.com/cpanse/protViz/issues
 Collate: aa2mass.R 
   centroid.R
+  centroidv2.R
   comet.R
   deisotoper.R
   de_novo.R 
@@ -53,3 +54,4 @@ LazyData: true
 NeedsCompilation: yes
 Repository: CRAN
 SystemRequirements: C++11
+RoxygenNote: 7.1.0

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -29,10 +29,11 @@ importFrom("stats", "weighted.mean")
 
 export("aa2mass")
 export("centroid")
+export("centroidv2")
 export("defaultIon")
 export("deisotoper")
 export("de_novo")
-export("findNN_", "lower_bound_")
+#export("findNN_", "lower_bound_")
 export("findNN")
 export("fragmentIon")
 export("genMod")
@@ -81,7 +82,7 @@ S3method(summary, cometdecoy)
 S3method(as.data.frame, mascot)
 S3method(findMz, mascot)
 S3method(as.psmSet, mascot)
-export("plot.mascot", "plot.mascot_query", "summary.mascot", 
+export("plot.mascot", "plot.mascot_query", "summary.mascot",
     "as.data.frame.mascot", "is.mascot", "is.mascot_query",
     "summary.cometdecoy",
     "findMz.mascot", "as.psm.mascot_query")

--- a/R/centroidv2.R
+++ b/R/centroidv2.R
@@ -1,0 +1,36 @@
+.getpeakpos <- function(mz, intensity){
+  peakpos <- which(diff(sign(diff(intensity))) == -2) + 1
+  peakstart <- which(diff(sign(diff(intensity))) == 2) + 1
+  peakstart <- rep(peakstart,2)
+  peakstartsimple <- which(diff(sign(diff(intensity))) == 1) + 1
+  peakstarts <- sort(c(peakstart, peakstartsimple))
+  peakstartsM <- matrix(peakstarts, ncol = 2, byrow = T)
+  colnames(peakstartsM) <- c("start", "end")
+  peakidx <- cbind(peakpos = peakpos , start = peakstartsM[,"start"], end  = peakstartsM[,"end"])
+  return(peakidx)
+}
+
+
+centroidv2 <- function(mZ, intensity,
+                       .funpos = .getpeakpos,
+                       .funtrapez = protViz:::.trapez,
+                       .funapex = weighted.mean){
+  peakidx <- .funpos(mZ, intensity)
+
+
+
+
+  getCentroid <- function(pidx){
+    i <- pidx["start"]:pidx["end"]
+    intensity.auc <- .funtrapez(mZ[i], intensity[i])
+    apexgroup <- (pidx["peakpos"] - 1):(pidx["peakpos"] + 1)
+    mZ.centroid <- .funapex( mZ[apexgroup], intensity[apexgroup])
+    return(c(mZ = mZ.centroid, intensity = intensity.auc))
+  }
+
+  res <- data.frame(t(apply(peakidx,1,getCentroid)))
+  return(res)
+}
+
+
+

--- a/man/centroidv2.Rd
+++ b/man/centroidv2.Rd
@@ -1,0 +1,98 @@
+\name{centroidv2}
+\alias{centroidv2}
+\alias{profile}
+\title{
+  Centroid a spectrum acquired in profile mode
+}
+\description{
+  returns a centroid spectrum of a recorded profile mode spectrum.
+}
+\usage{
+  centroid(mZ, intensity, eps=0.1, debug=FALSE)
+}
+\arguments{
+
+  \item{mZ}{Numerical vector of profile recorded data and sorted mZ values.}
+
+  \item{intensity}{corresponding intensity values.}
+
+}
+\details{
+  the method is tested on an Orbitrap Fusion Lumos FSN20242 data set.
+}
+
+\value{
+  returns a \code{data.frame} with a mZ and a intensity column.
+}
+
+\author{
+  Witold Wolski, April 2020
+}
+
+\note{
+  thanks to Nienke Meekel and Andrea Brunner (kwrwater.nl).
+}
+
+
+
+\examples{
+  # Orbitrap Fusion Lumos FSN20242
+  # p2722/.../.../stds_pos_neg_MS_highconc_UVPD_50_300.raw
+  # scan 1959
+  # CC(C)(C)C(O)C(OC1=CC=C(Cl)C=C1)N1C=NC=N1	1
+  # exact.mass 295.1088
+  # FTMS + p ESI d Full ms2 296.1162@uvpd50.00
+
+    p <- protViz:::.getProfileMS2()
+
+    names(p)
+    eps = 0.1
+    mZ <- p$mZ
+    intensity <- p$intensity
+    n <- length(mZ)
+
+    rv2 <- centroidv2(p$mZ, p$intensity)
+    rv <- protViz::centroid(p$mZ, p$intensity, debug = FALSE)
+
+    peakidx <- protViz:::.getpeakpos(mZ, intensity)
+
+    par(mfrow = c(2,2), mar = c(3,4,3,3))
+    plot(mZ, intensity, type = "h", log = "y", xlim = c(147.45,147.6), main = "peak boundaries")
+    abline(v = mZ[peakidx[,"peakpos"]], col = 2, lty = 2)
+    abline(v = mZ[peakidx[,"start"]], col = 3, lty = 2)
+    abline(v = mZ[peakidx[,"end"]], col = 4, lty = 4)
+
+    plot(rv2$mZ, rv2$intensity,
+         type = 'h',
+         log = "y",
+         col = "green",
+         xlim = c(100,200),
+         ylim = c(1,100000))
+    lines(rv$mZ, rv$intensity, type = 'h')
+    lines(p$mZ, p$intensity, col = "grey")
+    legend("topleft", legend = c("centroid","centroidv2"), col = c("black", "green","grey"), lty = c(1,1))
+
+    plot(rv2$mZ, rv2$intensity,
+         type = 'h', log = "y", col = "green",
+         xlim = c(113.7,113.75),
+         ylim = c(1,20000))
+
+    lines(rv$mZ, rv$intensity, type = 'h')
+    lines(p$mZ, p$intensity, col = "grey", type = "b")
+    legend("topleft",
+           legend = c("centroid","centroidv2","raw"),
+           col = c("black", "green","grey"),
+           lty = c(1,1,1))
+
+    plot(rv2$mZ, rv2$intensity, type = 'h', log = "y", col = "green",
+         xlim = c(147.45,147.6),
+         ylim = c(1,20000))
+    lines(rv$mZ, rv$intensity, type = 'h')
+    lines(p$mZ, p$intensity, col = "grey", type = "b")
+    legend("topleft", legend = c("centroid","centroidv2","raw"), col = c("black", "green","grey"), lty = c(1,1,1))
+
+}
+% Add one or more standard keywords, see file 'KEYWORDS' in the
+% R documentation directory.
+\keyword{centroid}% use one of  RShowDoc("KEYWORDS")
+\keyword{profile}% __ONLY ONE__ keyword per line

--- a/man/centroidv2.Rd
+++ b/man/centroidv2.Rd
@@ -1,0 +1,88 @@
+\name{centroidv2}
+\alias{centroidv2}
+\alias{profile}
+\title{
+  Centroid a spectrum acquired in profile mode
+}
+\description{
+  returns a centroid spectrum of a recorded profile mode spectrum.
+}
+\usage{
+  centroid(mZ, intensity, eps=0.1, debug=FALSE)
+}
+\arguments{
+
+  \item{mZ}{Numerical vector of profile recorded data and sorted mZ values.}
+
+  \item{intensity}{corresponding intensity values.}
+
+}
+\details{
+  the method is tested on an Orbitrap Fusion Lumos FSN20242 data set.
+}
+
+\value{
+  returns a \code{data.frame} with a mZ and a intensity column.
+}
+
+\author{
+  Witold Wolski, April 2020
+}
+
+\note{
+  thanks to Nienke Meekel and Andrea Brunner (kwrwater.nl).
+}
+
+
+
+\examples{
+  # Orbitrap Fusion Lumos FSN20242
+  # p2722/.../.../stds_pos_neg_MS_highconc_UVPD_50_300.raw
+  # scan 1959
+  # CC(C)(C)C(O)C(OC1=CC=C(Cl)C=C1)N1C=NC=N1	1
+  # exact.mass 295.1088
+  # FTMS + p ESI d Full ms2 296.1162@uvpd50.00
+
+    p <- protViz:::.getProfileMS2()
+
+    names(p)
+    eps = 0.1
+    mZ <- p$mZ
+    intensity <- p$intensity
+    n <- length(mZ)
+
+
+
+
+    rv2 <- centroidv2(p$mZ, p$intensity)
+    rv <- protViz::centroid(p$mZ, p$intensity, debug = FALSE)
+
+    peakidx <- protViz:::.getpeakpos(mZ, intensity)
+
+    par(mfrow = c(2,2))
+    plot(mZ, intensity, type = "h", log = "y", xlim = c(147.45,147.6), main = "peak boundaries")
+    abline(v = mZ[peakidx[,"peakpos"]], col = 2, lty = 2)
+    abline(v = mZ[peakidx[,"start"]], col = 3, lty = 2)
+    abline(v = mZ[peakidx[,"end"]], col = 4, lty = 4)
+
+
+    plot(rv2$mZ, rv2$intensity, type = 'h', log = "y", col = "green", xlim = c(100,200))
+    lines(rv$mZ, rv$intensity, type = 'h')
+    lines(p$mZ, p$intensity, col = "grey")
+    legend("topleft", legend = c("centroid","centroidv2"), col = c("black", "green","grey"), lty = c(1,1))
+
+    plot(rv2$mZ, rv2$intensity, type = 'h', log = "y", col = "green", xlim = c(113,114))
+    lines(rv$mZ, rv$intensity, type = 'h')
+    lines(p$mZ, p$intensity, col = "grey")
+    legend("topleft", legend = c("centroid","centroidv2","raw"), col = c("black", "green","grey"), lty = c(1,1,1))
+
+    plot(rv2$mZ, rv2$intensity, type = 'h', log = "y", col = "green", xlim = c(147.45,147.6))
+    lines(rv$mZ, rv$intensity, type = 'h')
+    lines(p$mZ, p$intensity, col = "grey")
+    legend("topleft", legend = c("centroid","centroidv2","raw"), col = c("black", "green","grey"), lty = c(1,1,1))
+
+}
+% Add one or more standard keywords, see file 'KEYWORDS' in the
+% R documentation directory.
+\keyword{centroid}% use one of  RShowDoc("KEYWORDS")
+\keyword{profile}% __ONLY ONE__ keyword per line


### PR DESCRIPTION
Hi,

I did implement a slightly different version of centroid and called it centroidv2. It uses `diff` to find the peak maxima and peak starts and ends and does not require the `eps` parameter. The implementation is more concise. With the sample data it seems to pick all the peaks which centroid does. See figure below. Of course it will need more testing.

![centroid_vs_centroidv2](https://user-images.githubusercontent.com/1926513/80109785-36346b80-857e-11ea-8a9b-2614b52a7ce1.png)

Could you please review my pull request?


